### PR TITLE
Ocean::list - do not strip away "/" in item paths

### DIFF
--- a/lib/ocman/folder.rb
+++ b/lib/ocman/folder.rb
@@ -11,7 +11,7 @@ module Ocman
 
       Ocman::Dav.new.ls(URI.encode(path), options) do |item|
         accu << Hashie::Mash.new({
-          path: URI.decode(item.uri.to_s.gsub(Ocman::Dav.url(path), '').gsub('/', '')),
+          path: URI.decode(item.uri.to_s.gsub(Ocman::Dav.url(path), '')),
           type: item.type.to_s,
           size: item.size
         })


### PR DESCRIPTION
When listing files, the path was returned with all "/" stripped away, so I was not able to download the files anymore.

I do not know, whether that was expected behavior, but with this change, one can simply get the `.path` and download the file right away.